### PR TITLE
backport close race condition fix from 1.3

### DIFF
--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -139,13 +139,13 @@ FileWriter.prototype = {
             function finish(err) {
                 if (guard && global.clearTimeout) clearTimeout(guard);
                 guard = null;
-                if (fd !== null) fs.close(fd, function(){});
+                if (fd !== null) try { fs.closeSync(fd) } catch (e) { }
                 fd = null;
                 return error ? cb(error) : cb(err);
             }
             try {
                 guard = setTimeout(function() {
-                    if (fd !== null) fs.close(fd, function(){});
+                    if (fd !== null) try { fs.closeSync(fd) } catch (e) { }
                     error = new Error("timed out waiting for last write");
                     return finish(error);
                 }, mutexTimeout)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
this got fixed during the refactor without it being caught as the source of a race condition.
This is a minimal patch to the 1.2 branch; qfputs-1.3 and 1.4 do  not have this issue.