### PR TITLE
Review 1.2.7 1.7.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -84,7 +84,7 @@ will be called with first write error, and the error state cleared.
 
 ### renameFile( oldName, newName, [waitMs,] callback(err) )
 
-Convenience function, exposes writable.renameFile if writable is a FileWriter.
+Convenience function, exposes writable.renameFile.
 
 ## Helper Classes
 

--- a/Readme.md
+++ b/Readme.md
@@ -109,9 +109,9 @@ callback of the first `drain` or `fflush` to be called.
 If the qfputs object is already in use when the error handler is installed, it can
 be called immediately if there already is a waiting unreported error.
 
-### renameFile( oldName, newName, [waitMs,] callback(err) )
+### renameFile( oldName, newName, [options,] callback(err) )
 
-Convenience function, exposes FileWriter.renameFile.
+Convenience function, exposes `FileWriter.renameFile`.
 
 
 Helper Classes

--- a/Readme.md
+++ b/Readme.md
@@ -2,11 +2,11 @@ qfputs
 ======
 
 Very fast buffered write-combining string and binary data output.
-Similar to [C](http://www.cplusplus.com/reference/cstdio/puts/) or
+Similar to [C puts()](http://www.cplusplus.com/reference/cstdio/puts/) or
 [php fputs()](http://php.net/manual/en/function.fputs.php).
 
-The data can be written as newline terminated lines with `fputs`,
-or in bulk with `write`.  Lines, bulk data, strings and Buffers can
+The data can be written as newline terminated lines with `fputs()`,
+or in bulk with `write()`.  Lines, bulk data, strings and Buffers can
 be mixed at will.
 
 Data is buffered and written in batches in the background.  Uses any
@@ -14,7 +14,7 @@ data writer with a `write()` method taking a callback, eg node write
 streams.
 
 Install an error handler with `setOnError()` to be notified of all write errors.
-Otherwise, write errors are reported to drain() or fflush().
+Otherwise, write errors are reported to `drain()` or `fflush()`.
 
 For high file write speeds, the built-in `Fputs.FileWriter` can handle
 over a million 200-byte mutexed writes / second to disk (over 2 mill /sec
@@ -54,14 +54,15 @@ string filename.  If a string, an Fputs.FileWriter will be used (see below).
 
 Options:
 
-- `writemode`:   file open mode to use with a filename writable, default 'a'
-- `writesize`:   number of chars to write per chunk, default 100k
-- `highWaterMark`:  the number of chars buffered before write returns false, default writesize
+- `writemode` - file open mode to use with a filename writable, default 'a'
+- `writesize` - number of chars to write per chunk, default 100k
+- `highWaterMark` - the number of chars buffered before write returns false, default writesize
 
 ### fputs( line )
 
 Append the line to the file.  If the line is not already newline terminated,
-it will get a newline appended like `puts()`.  Line must be a string.
+it will get a newline appended, like C `puts()`.  Line must be a string, else
+will be coerced to a string.
 
 Returns true, or false if the buffer is above the highWaterMark.
 
@@ -70,8 +71,8 @@ Returns true, or false if the buffer is above the highWaterMark.
 Append the data to the file.  Newline termination is presumed, but not checked.
 This call is intended for bulk transport of newline delimited data.
 The caller is responsible for splitting the bulk data on line boundaries.
-Data can be a string of a Buffer.  Separate data chunks will be concatenated
-before being written for higher write speed.
+Data can be a string of a Buffer, else will be coerced to a string.  Data
+items will be concatenated before being written for higher write speed.
 
 The callback is optional.  If provided, it is called as soon as the data
 is buffered, not when actually written.  Use fflush() to wait for the
@@ -82,7 +83,8 @@ Returns true, or false if the buffer is above the highWaterMark.
 ### drain( [maxUnwritten], callback(error) )
 
 Wait for the un-written buffered data to shrink to no more than maxUnwritten
-chars.  If maxUnwritten is omitted, the built-in default of 200 KB is used.
+chars.  If maxUnwritten is omitted, the built-in default of `2 * writesize`
+(200 KB) is used.
 
 If unreported write errors occurred since the last call to fflush or drain, the callback
 will be called with first write error, the error state cleared.
@@ -109,7 +111,7 @@ be called immediately if there already is a waiting unreported error.
 
 ### renameFile( oldName, newName, [waitMs,] callback(err) )
 
-Convenience function, exposes writable.renameFile.
+Convenience function, exposes FileWriter.renameFile.
 
 
 Helper Classes
@@ -235,3 +237,10 @@ ChangeLog
 ### 1.0.0
 
 - initial version, 2014-09-30
+
+
+Todo
+----
+
+- pass options to renameFile(fm, to, [opts|waitMs], cb), to clean up the mutexTimeout mess
+- maybe FileWriter.getLockedFd should use mutexTimeout?

--- a/Readme.md
+++ b/Readme.md
@@ -194,6 +194,12 @@ Todo
 ChangeLog
 ---------
 
+### 1.7.0
+
+- upgrade to the faster aflow 0.10.0
+- upgrade to fs-ext 0.5.0 to work with node-v4 and node-v5
+- use qnit for unit tests
+
 ### 1.6.0
 
 - abort() method to discard unwritten data and return when last write finishes

--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,20 @@ Wait for all buffered data to be written.
 If unreported write errors occurred since the last call to fflush or drain, the callback
 will be called with first write error, and the error state cleared.
 
+### abort( callback(error) )
+
+Wait for the current write to finish but discard all other unwritten data.
+
+Any unreported write error will be returned via the callback.
+
+### getUnwrittenLength( )
+
+Return the estimated length of data remaining to be written.
+
+Strings are estimated in characters, Buffers in bytes.  Strings converted to
+Buffers for write-combining also adjust the expected length to keep drain and
+fflush in sync with writes.
+
 ### setOnError( errorHandler(err) )
 
 Call the error handler function on write errors instead of saving them for reprting
@@ -175,7 +189,6 @@ Todo
 
 - maybe FileWriter.getLockedFd should use mutexTimeout?
 - use a stack for fflush callbacks
-- rename vars unwrittenLength -> bufferedLength, str -> data
 
 
 ChangeLog

--- a/Readme.md
+++ b/Readme.md
@@ -150,13 +150,19 @@ multiple simultaneous updates.  Data can be either an utf8 string or a Buffer.
 
 The FileWriter callback is called after the write completes.
 
-#### renameFile( oldName, newName, [waitMs,] callback(err) )
+#### renameFile( oldName, newName, [options,] callback(err) )
 
 Rename the logfile and wait for writes to settle.  It is assumed that new
 writes can start for only at most `waitMs` milliseconds before the writers
 reopen the old filename.  The FileWriter built-in reopen interval is 50 ms.
-Times out if a write takes longer than fp.mutexTimeout seconds (5 sec default).
+Times out if a write takes longer than `mutexTimeout` seconds (5 sec default).
 
+If `options` is a number it will be understood to mean `waitMs`.
+
+Options:
+
+- `waitMs` - milliseconds to wait for writes to settle (default 50)
+- `mutexTimeout` - milliseconds to allow for an ongoing write to finish (default 5000)
 
 Notes
 -----
@@ -242,5 +248,4 @@ ChangeLog
 Todo
 ----
 
-- pass options to renameFile(fm, to, [opts|waitMs], cb), to clean up the mutexTimeout mess
 - maybe FileWriter.getLockedFd should use mutexTimeout?

--- a/Readme.md
+++ b/Readme.md
@@ -98,7 +98,7 @@ On initial open the specified openmode is used.  File handles are used for at
 most .05 seconds, then are reopened.  On reopen, files initially opened 'w' or
 'w+' are reopened 'r+' to not overwrite the just written contents.
 
-#### new Fputs.FileWriter( filename, [openmode] )
+#### new Fputs.FileWriter( filename, [openmode|opts] )
 
 Create a FileWriter that will append the named file.  The file is "lazy"
 created/opened on first access.  The default openmode is 'a', append-only.
@@ -108,11 +108,16 @@ created/opened on first access.  The default openmode is 'a', append-only.
 
         fp.fputs("Hello, line!\n");
 
-#### write( string, callback(error, numBytes) )
+If instead of an openmode string an options object is given, the fields are
 
-Write the text to the file, and call callback when done.  Writes are done
-under an exclusive write lock, `flock(LOCK_EX)`, to guarantee the integrity of
-the data with multiple simultaneous updates.
+- `openmode` - file open mode, default 'a'
+- `writesize` - written data target size, default 102400
+
+#### write( data, callback(error, numBytes) )
+
+Write the data to the file, and call callback when done.  Writes are done under an
+exclusive write lock, `flock(LOCK_EX)`, to guarantee the integrity of the data with
+multiple simultaneous updates.  Data can be either an utf8 string or a Buffer.
 
 The FileWriter callback is called after the write completes.
 

--- a/Readme.md
+++ b/Readme.md
@@ -209,6 +209,7 @@ ChangeLog
 ### 1.3.0
 
 - refactor renameFile using `aflow.series()`
+- add support for `FileWriter.write()` of Buffer data
 - reuse a single filewriter Buffer to spare the process rss
 
 ### 1.2.2

--- a/Readme.md
+++ b/Readme.md
@@ -125,8 +125,8 @@ The FileWriter callback is called after the write completes.
 
 Rename the logfile and wait for writes to settle.  It is assumed that new
 writes can start for only at most `waitMs` milliseconds before the writers
-reopen the old filename.  Times out if a write takes longer than
-fp.mutexTimeout seconds (5 sec default).
+reopen the old filename.  The FileWriter built-in reopen interval is 50 ms.
+Times out if a write takes longer than fp.mutexTimeout seconds (5 sec default).
 
 ## Notes
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 qfputs
 ======
 
-Very fast buffered write-combining string and binary data output.
+Quick write-combining buffered string and binary data output.
 Similar to [C puts()](http://www.cplusplus.com/reference/cstdio/puts/) or
 [php fputs()](http://php.net/manual/en/function.fputs.php).
 

--- a/Readme.md
+++ b/Readme.md
@@ -149,6 +149,10 @@ Times out if a write takes longer than fp.mutexTimeout seconds (5 sec default).
 
 ## ChangeLog
 
+### 1.2.4
+
+- backport renameFile close() race condition fix from 1.3
+
 ### 1.4.0
 
 - setOnError() method

--- a/Readme.md
+++ b/Readme.md
@@ -176,6 +176,7 @@ ChangeLog
 ### 1.5.0
 
 - add support for write() of Buffer data, also mix of Buffer and string
+- allow options to `renameFile`
 
 ### 1.4.2
 

--- a/Readme.md
+++ b/Readme.md
@@ -174,10 +174,15 @@ Todo
 ----
 
 - maybe FileWriter.getLockedFd should use mutexTimeout?
+- getUnwrittenLength() method to return how much is still left to write
 
 
 ChangeLog
 ---------
+
+### 1.6.0
+
+- abort() method
 
 ### 1.5.0
 

--- a/Readme.md
+++ b/Readme.md
@@ -170,6 +170,12 @@ Notes
 - The included Fputs.FileWriter uses `fs-ext`, which is a C++ extension.
 
 
+Todo
+----
+
+- maybe FileWriter.getLockedFd should use mutexTimeout?
+
+
 ChangeLog
 ---------
 
@@ -244,9 +250,3 @@ ChangeLog
 ### 1.0.0
 
 - initial version, 2014-09-30
-
-
-Todo
-----
-
-- maybe FileWriter.getLockedFd should use mutexTimeout?

--- a/Readme.md
+++ b/Readme.md
@@ -174,7 +174,8 @@ Todo
 ----
 
 - maybe FileWriter.getLockedFd should use mutexTimeout?
-- getUnwrittenLength() method to return how much is still left to write
+- use a stack for fflush callbacks
+- rename vars unwrittenLength -> bufferedLength, str -> data
 
 
 ChangeLog
@@ -182,7 +183,9 @@ ChangeLog
 
 ### 1.6.0
 
-- abort() method
+- abort() method to discard unwritten data and return when last write finishes
+- getUnwrittenLength() method
+- speed up interleaved string-buffer-string writes
 
 ### 1.5.0
 

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -28,7 +28,9 @@ module.exports = FileWriter;
 function FileWriter( filename, openmode ) {
     if (!(this instanceof FileWriter)) return new FileWriter(filename, openmode);
     if (!filename) throw new Error("missing filename");
-    openmode = openmode || "a";
+    var opts = typeof openmode === 'object' ? openmode : {openmode: openmode};
+    openmode = opts.openmode || "a";
+    var writesize = opts.writesize || 102400;
 
     this._isFileWriter = true;
     this.filename = filename;
@@ -42,6 +44,7 @@ function FileWriter( filename, openmode ) {
     this.reopenTime = 0;
     this.isFirstOpen = true;
     this.fd = undefined;
+    this._writebuf = new Buffer(writesize * 1.25);
 }
 
 FileWriter.prototype = {
@@ -104,19 +107,26 @@ FileWriter.prototype = {
     },
 
     // atomically append the string to the file
-    write: function write(str, nbytes, cb) {
+    write: function write(str, cb) {
         var self = this;
-        if (!cb) { cb = nbytes; nbytes = null }
         this._getLockedFd(function(err, fd) {
             if (err) return cb(err);
-            // not much benefit to reusing a buffer for the writes
-            var buf;
-            if (Buffer.isBuffer(str)) buf = str;
-            else {
-                buf = new Buffer(nbytes !== null ? str.slice(0, nbytes) : str);
+            var buf, nbytes;
+            if (Buffer.isBuffer(str)) {
+                buf = str;
                 nbytes = buf.length;
             }
-            fs.write(fd, buf, 0, nbytes || buf.length, null, function(err, nb) {
+            else {
+                // reuse the write buffer as much as possible, to cut down on rss churn
+                buf = self._writebuf;
+                nbytes = buf.write(str);
+                if (nbytes > buf.length - 10) {
+                    buf = new Buffer(str);
+                    nbytes = buf.length;
+                }
+            }
+            // write(fd, buf, bufOffset, byteCount, fileOffset, cb)
+            fs.write(fd, buf, 0, nbytes, null, function(err, nb) {
                 flockSync(fd, "un");
                 cb(err, nb);
             });

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -121,7 +121,7 @@ FileWriter.prototype = {
                 // reuse the write buffer as much as possible, to cut down on rss churn
                 buf = self._writebuf;
                 nbytes = buf.write(str);
-                if (nbytes > buf.length - 10) {
+                if (nbytes > buf.length - 4) {
                     buf = new Buffer(str);
                     nbytes = buf.length;
                 }

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -180,13 +180,14 @@ FileWriter.prototype = {
             function(cb) {
                 // obtain a write lock on the file to ensure that the very last write is done.
                 // Error out if the write takes longer than mutexTimeout to finish.
-                // note: this function can call cb() twice, but aflow.series will ignore the second
                 // an ENOENT or EACCESS from here means the target file was deleted or read-protected
+                var done = false;
+                function cbOnce(err) { if (!done) { done = true; cb(err) } }
                 guard = setTimeout(function() {
-                    cb(new Error("timed out waiting for last write to finish"));
+                    cbOnce(new Error("timed out waiting for last write to finish"));
                 }, mutexTimeout);
                 fd = fs.openSync(newName, 'r');
-                fse.flock(fd, 'ex', cb);
+                fse.flock(fd, 'ex', cbOnce);
             },
         ],
             function(err) {

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -148,7 +148,12 @@ FileWriter.prototype = {
             callback = waitMs;
             waitMs = 50;
         }
-        var mutexTimeout = (this && this.mutexTimeout) ? this.mutexTimeout : FileWriter.mutexTimeout;
+        var options = {};
+        if (typeof waitMs === 'object') {
+            options = waitMs;
+            waitMs = options.waitMs || 50;
+        }
+        var mutexTimeout = options.mutexTimeout || ((this && this.mutexTimeout) ? this.mutexTimeout : FileWriter.mutexTimeout);
         var fd, guard;
 
         aflow.series([

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -55,7 +55,7 @@ FileWriter.prototype = {
         var mode = this.isFirstOpen ? this.openmode : this.reopenmode;
 
         if (this.fd !== undefined) {
-            fs.closeSync(this.fd);
+            try { fs.closeSync(this.fd); } catch (err) { console.log("FileWriter._reopenFd: closeSync: " + err.message) }
             this.fd = undefined;
         }
 
@@ -137,7 +137,7 @@ FileWriter.prototype = {
     // close the file
     close: function close( ) {
         try { if (this.fd) fs.closeSync(this.fd); }
-        catch (err) { }
+        catch (err) { console.log("FileWriter.close: closeSync: " + err.message) }
         this.fd = undefined;
     },
 

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -194,7 +194,7 @@ FileWriter.prototype = {
                 // the renamed file, still locked by us, is ready to use
                 if (guard && global.clearTimeout) clearTimeout(guard);
                 // closing the file descriptor also releases the lock
-                if (fd !== undefined) try { fs.closeSync(fd) } catch (e) { }
+                if (fd !== undefined) try { fs.closeSync(fd) } catch (e) { err = err || e }
                 return callback(err);
             }
         )

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -12,6 +12,7 @@
 
 var fs = require('fs');
 var fse = require('./fs-ext.js');
+var aflow = require('aflow');
 
 var flock = fse.flock;
 var flockSync = function( fd, mode ) {
@@ -142,62 +143,60 @@ FileWriter.prototype = {
 
     // rename the file and wait for write activity to cease
     mutexTimeout: 5000,
-    renameFile: function renameFile( oldName, newName, waitMs, cb ) {
-        if (!cb && typeof waitMs === 'function') {
-            cb = waitMs;
+    renameFile: function renameFile( oldName, newName, waitMs, callback ) {
+        if (!callback && typeof waitMs === 'function') {
+            callback = waitMs;
             waitMs = 50;
         }
-        // Wait for all pending writes to finish.  After waitMs no writer will reuse the old fd,
-        // and once we`ve paused and have the mutex we know that no more writes will occur.
-        var fd = null, mutexTimeout = (this && this.mutexTimeout) ? this.mutexTimeout : FileWriter.mutexTimeout;
-        function waitForWritesToFinish( ) {
-            var guard, error = null;
-            function finish(err) {
-                if (guard && global.clearTimeout) clearTimeout(guard);
-                guard = null;
-                if (fd !== null) fs.close(fd, function(){});
-                fd = null;
-                return error ? cb(error) : cb(err);
-            }
-            try {
+        var mutexTimeout = (this && this.mutexTimeout) ? this.mutexTimeout : FileWriter.mutexTimeout;
+        var fd, guard;
+
+        aflow.series([
+            function(cb) {
+                // only rename if the source exists, otherwise an empty newName would be created "wx" below
+                // note: race condition: if the source disappears, an empty newName can be created anyway
+                // note: filesystem metadata operations like open/close are much much faster as sync
+                // an ENOENT error from here means the source file oldName does not exist
+                // note: aflow.series catches errors thrown in these functions
+                fs.closeSync(fs.openSync(oldName, "r"));
+                cb();
+            },
+            function(cb) {
+                // renameSync overwrites an existing newName, does not throw an error
+                // prevent a rename-rename race condition by first getting exclusive rights to newName
+                // an EEXIST error from here means the target file newName already exists
+                fs.closeSync(fs.openSync(newName, 'wx'));
+                cb();
+            },
+            function(cb) {
+                // the actual rename
+                fs.renameSync(oldName, newName);
+                cb();
+            },
+            function(cb) {
+                // Wait for all writers to release the file.  After waitMs no writer will reuse an old fd
+                setTimeout(cb, waitMs);
+            },
+            function(cb) {
+                // obtain a write lock on the file to ensure that the very last write is done.
+                // Error out if the write takes longer than mutexTimeout to finish.
+                // note: this function can call cb() twice, but aflow.series will ignore the second
+                // an ENOENT or EACCESS from here means the target file was deleted or read-protected
                 guard = setTimeout(function() {
-                    if (fd !== null) fs.close(fd, function(){});
-                    error = new Error("timed out waiting for last write");
-                    return finish(error);
-                }, mutexTimeout)
+                    cb(new Error("timed out waiting for last write to finish"));
+                }, mutexTimeout);
                 fd = fs.openSync(newName, 'r');
-                fse.flock(fd, 'ex', function() {
-                    try {
-                        fse.flockSync(fd, 'un');
-                        fs.closeSync(fd);
-                        if (!error) return finish();
-                    }
-                    catch (err) {
-                        if (!error) return finish(err);
-                    }
-                })
+                fse.flock(fd, 'ex', cb);
+            },
+        ],
+            function(err) {
+                // the renamed file, still locked by us, is ready to use
+                if (guard && global.clearTimeout) clearTimeout(guard);
+                // closing the file descriptor also releases the lock
+                if (fd !== undefined) try { fs.closeSync(fd) } catch (e) { }
+                return callback(err);
             }
-            catch (err) {
-                // open error, eg ENOENT or EACCESS
-                return finish(err);
-            }
-        }
-        try {
-            // only rename if the source exists, else an empty target is created "wx"
-            // note: race condition: if the source disappears, an empty newName can be created
-            var rfd = fs.openSync(oldName, "r");
-            fs.closeSync(rfd);
-            // renameSync overwrites an existing newName, does not throw an error
-            // prevent a rename-rename race condition by first getting exclusive rights to newName
-            var fd = fs.openSync(newName, 'wx');
-            fs.closeSync(fd);
-            fs.renameSync(oldName, newName);
-            setTimeout(waitForWritesToFinish, waitMs);
-        }
-        catch (err) {
-            // source file ENOENT does not exist or target EEXIST exists or rename error
-            return cb(err);
-        }
+        )
     },
 }
 

--- a/lib/filewriter.js
+++ b/lib/filewriter.js
@@ -104,13 +104,19 @@ FileWriter.prototype = {
     },
 
     // atomically append the string to the file
-    write: function write(str, cb) {
+    write: function write(str, nbytes, cb) {
         var self = this;
+        if (!cb) { cb = nbytes; nbytes = null }
         this._getLockedFd(function(err, fd) {
             if (err) return cb(err);
             // not much benefit to reusing a buffer for the writes
-            var buf = new Buffer(str);
-            fs.write(fd, buf, 0, buf.length, null, function(err, nb) {
+            var buf;
+            if (Buffer.isBuffer(str)) buf = str;
+            else {
+                buf = new Buffer(nbytes !== null ? str.slice(0, nbytes) : str);
+                nbytes = buf.length;
+            }
+            fs.write(fd, buf, 0, nbytes || buf.length, null, function(err, nb) {
                 flockSync(fd, "un");
                 cb(err, nb);
             });

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -187,6 +187,21 @@ module.exports = (function() {
         })();
     }
 
+    /**
+     * discard any unwritten data and wait for any write in progress to finish
+     */
+    Fputs.prototype.abort = function abort( callback ) {
+        var self = this;
+        this.datachunks = [];
+        if (!this._syncing) return callback(self.returnError());
+
+        // TODO: this._fflushCallbacks.push({n: this.unwrittenLength, f: callback})
+        (function waitloop() {
+            if (self._syncing) setTimeout(waitloop, 2);
+            else return callback(self.returnError());
+        })();
+    }
+
     // the sync thread runs whenever there is data waiting,
     // and tries to write chunks ending on line boundaries
     Fputs.prototype._sync = function _sync( ) {
@@ -204,6 +219,7 @@ module.exports = (function() {
             if (self.datachunks.length > 1) setImmediate(function(){ self._sync(); });
             else if (self.datachunks.length > 0) setTimeout(function(){ self._sync(); }, 1);
             else self._syncing = false;
+            // TODO: invoke fflush callbacks from here, to not have to poll
         });
 
         // This function is not reentrant, only one writer thread must run.

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -89,21 +89,21 @@ module.exports = (function() {
     /**
      * Write bulk data to the target.  Newline termination is not checked.
      */
-    Fputs.prototype.write = function write( str, callback ) {
-        var type = typeof str;
-        if (type === 'string' || !Buffer.isBuffer(str)) {
-            if (type !== 'string') str = "" + str;
+    Fputs.prototype.write = function write( dataItem, callback ) {
+        var type = typeof dataItem;
+        if (type === 'string' || !Buffer.isBuffer(dataItem)) {
+            if (type !== 'string') dataItem = "" + dataItem;
 
             // merge writes into this.writesize sized data chunks
             // it is assumed that all writes end with a newline (not checked)
             var nchunks = this.datachunks.length;
-            if (nchunks && typeof this.datachunks[nchunks-1] === 'string' && this.datachunks[nchunks-1].length + str.length <= this.writesize) {
+            if (nchunks && typeof this.datachunks[nchunks-1] === 'string' && this.datachunks[nchunks-1].length + dataItem.length <= this.writesize) {
                 // the last chunk has space for more
-                this.datachunks[nchunks-1] += str;
+                this.datachunks[nchunks-1] += dataItem;
             }
             else {
                 // else start a new chunk
-                this.datachunks.push(str);
+                this.datachunks.push(dataItem);
             }
         }
         else {
@@ -116,23 +116,23 @@ module.exports = (function() {
                     var chunk = new Buffer(lastChunk);
                     this.unwrittenLength += chunk.length - lastChunk.length;
                     chunks[nchunks-2].chunks.push(chunk);
-                    chunks[nchunks-2].chunks.push(str);
-                    chunks[nchunks-2].length += chunk.length + str.length;
+                    chunks[nchunks-2].chunks.push(dataItem);
+                    chunks[nchunks-2].length += chunk.length + dataItem.length;
                     chunks.pop();
                 }
                 else {
                     // if buffer follows string, combine them and swap the string for a list of buffers
                     var stringBuffer = new Buffer(lastChunk);
-                    chunks[chunks.length-1] = { length: stringBuffer.length + str.length, chunks: [stringBuffer, str] };
+                    chunks[chunks.length-1] = { length: stringBuffer.length + dataItem.length, chunks: [stringBuffer, dataItem] };
                     this.unwrittenLength += stringBuffer.length - lastChunk.length;
                 }
             }
             else if (typeof lastChunk === 'object' && lastChunk.length < this.writesize) {
-                lastChunk.chunks.push(str);
-                lastChunk.length += str.length;
+                lastChunk.chunks.push(dataItem);
+                lastChunk.length += dataItem.length;
             }
             else {
-                chunks.push({ length: str.length, chunks: [str] });
+                chunks.push({ length: dataItem.length, chunks: [dataItem] });
             }
         }
 
@@ -141,7 +141,7 @@ module.exports = (function() {
             this.writtenLength = this.unwrittenLength = 0;
             this.resetCount += 1;
         }
-        this.unwrittenLength += str.length;
+        this.unwrittenLength += dataItem.length;
 
         if (!this._syncing) {
             // if not currently syncing, start the sync thread
@@ -150,7 +150,7 @@ module.exports = (function() {
             this._syncing = true;
         }
 
-        if (callback) callback(null, str.length);
+        if (callback) callback(null, dataItem.length);
         return this.unwrittenLength - this.writtenLength <= this.highWaterMark;
     }
 

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -46,8 +46,6 @@ module.exports = (function() {
 
         this._error = null;
         this._onError = null;
-        this.reportError = function(err) { if (!this._error) this._error = err; if (this._onError) this._onError(err) }
-        this.returnError = function() { var err = this._error; this._error = null; return err; }
     }
 
     // export FileWriter on the Fputs class
@@ -60,14 +58,20 @@ module.exports = (function() {
     Fputs.prototype.renameFile = FileWriter.renameFile;
 
     Fputs.prototype.reportError = function( err ) {
-        if (!this._error) this._error = err;
         if (this._onError) this._onError(err);
+        else if (!this._error) this._error = err;
     },
 
     Fputs.prototype.returnError = function( ) {
         var err = this._error;
         this._error = null;
         return err;
+    },
+
+    Fputs.prototype.setOnError = function setOnError( handler ) {
+        this._onError = handler;
+        if (this._error) handler(this.returnError())
+        return this;
     },
 
     /**

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -74,6 +74,10 @@ module.exports = (function() {
         return this;
     },
 
+    Fputs.prototype.getUnwrittenLength = function getUnwrittenLength( ) {
+        return this.unwrittenLength - this.writtenLength;
+    },
+
     /**
      * Append a newline terminated string to the fifo.
      */
@@ -108,16 +112,19 @@ module.exports = (function() {
             if (typeof lastChunk === 'string' && lastChunk.length < this.writesize) {
                 if (nchunks >= 2 && typeof chunks[nchunks-2] === 'object' && chunks[nchunks-2].length < this.writesize*2) {
                     // if possible, much more efficient to combine buffer-string-buffer into buffer-buffer-buffer
+                    // be sure to adjust the buffered length to keep drain and flush synced up
                     var chunk = new Buffer(lastChunk);
+                    this.unwrittenLength += chunk.length - lastChunk.length;
                     chunks[nchunks-2].chunks.push(chunk);
                     chunks[nchunks-2].chunks.push(str);
                     chunks[nchunks-2].length += chunk.length + str.length;
                     chunks.pop();
                 }
                 else {
-                    lastChunk = { length: lastChunk.length + str.length, chunks: [new Buffer(lastChunk), str] };
-                    chunks.pop();
-                    chunks.push(lastChunk);
+                    // if buffer follows string, combine them and swap the string for a list of buffers
+                    var stringBuffer = new Buffer(lastChunk);
+                    chunks[chunks.length-1] = { length: stringBuffer.length + str.length, chunks: [stringBuffer, str] };
+                    this.unwrittenLength += stringBuffer.length - lastChunk.length;
                 }
             }
             else if (typeof lastChunk === 'object' && lastChunk.length < this.writesize) {

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -52,7 +52,7 @@ module.exports = (function() {
     Fputs.FileWriter = FileWriter;
 
 
-    // export renameFile as a QFputs class method and instance method
+    // export renameFile as both a QFputs class method and instance method
     Fputs.renameFile = FileWriter.renameFile;
     Fputs.prototype.mutexTimeout = FileWriter.mutexTimeout;
     Fputs.prototype.renameFile = FileWriter.renameFile;

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -86,18 +86,47 @@ module.exports = (function() {
      * Write bulk data to the target.  Newline termination is not checked.
      */
     Fputs.prototype.write = function write( str, callback ) {
-        if (typeof str !== 'string') str = "" + str;
+        var type = typeof str;
+        if (type === 'string' || !Buffer.isBuffer(str)) {
+            if (type !== 'string') str = "" + str;
 
-        // merge writes into this.writesize sized data chunks
-        // it is assumed that all writes end with a newline (not checked)
-        var nchunks = this.datachunks.length;
-        if (nchunks > 0 && this.datachunks[nchunks-1].length + str.length <= this.writesize) {
-            // the last chunk has space for more
-            this.datachunks[nchunks-1] += str;
+            // merge writes into this.writesize sized data chunks
+            // it is assumed that all writes end with a newline (not checked)
+            var nchunks = this.datachunks.length;
+            if (nchunks && typeof this.datachunks[nchunks-1] === 'string' && this.datachunks[nchunks-1].length + str.length <= this.writesize) {
+                // the last chunk has space for more
+                this.datachunks[nchunks-1] += str;
+            }
+            else {
+                // else start a new chunk
+                this.datachunks.push(str);
+            }
         }
         else {
-            // else start a new chunk
-            this.datachunks.push(str);
+            var chunks = this.datachunks, nchunks = chunks.length;
+            var lastChunk = nchunks ? chunks[nchunks-1] : undefined;
+            if (typeof lastChunk === 'string' && lastChunk.length < this.writesize) {
+                if (nchunks >= 2 && typeof chunks[nchunks-2] === 'object' && chunks[nchunks-2].length < this.writesize*2) {
+                    // if possible, much more efficient to combine buffer-string-buffer into buffer-buffer-buffer
+                    var chunk = new Buffer(lastChunk);
+                    chunks[nchunks-2].chunks.push(chunk);
+                    chunks[nchunks-2].chunks.push(str);
+                    chunks[nchunks-2].length += chunk.length + str.length;
+                    chunks.pop();
+                }
+                else {
+                    lastChunk = { length: lastChunk.length + str.length, chunks: [new Buffer(lastChunk), str] };
+                    chunks.pop();
+                    chunks.push(lastChunk);
+                }
+            }
+            else if (typeof lastChunk === 'object' && lastChunk.length < this.writesize) {
+                lastChunk.chunks.push(str);
+                lastChunk.length += str.length;
+            }
+            else {
+                chunks.push({ length: str.length, chunks: [str] });
+            }
         }
 
         if (this.writtenLength && this.writtenLength >= this.unwrittenLength) {
@@ -167,6 +196,7 @@ module.exports = (function() {
         }
 
         var chunk = this.datachunks.shift();
+        if (typeof chunk !== 'string') chunk = Buffer.concat(chunk.chunks);
         var self = this;
         this.writable.write(chunk, function(err, ret) {
             self.writtenLength += chunk.length;

--- a/lib/fputs.js
+++ b/lib/fputs.js
@@ -27,14 +27,16 @@ module.exports = (function() {
         if (!(this instanceof Fputs)) return new Fputs(writable, opts);
 
         opts = opts || {};
+        var openmode = opts.writemode || 'a';
+        var writesize = opts.writesize || 102400;
         if (typeof writable === 'string') {
             // convert a string filename into a FileWriter writable
-            writable = new Fputs.FileWriter(writable, opts.writemode || 'a');
+            writable = new Fputs.FileWriter(writable, {openmode: openmode, writesize: writesize});
         }
         if (!writable) writable = process.stdout;
 
         this.writable = writable;
-        this.writesize = opts.writesize || 102400;
+        this.writesize = writesize;
         this.highWaterMark = opts.highWaterMark || this.writesize;
         this.datachunks = [];
         this.unwrittenLength = 0;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "transport"
   ],
   "dependencies": {
+    "aflow": "0.9.3",
     "fs-ext": "0.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qfputs",
   "version": "1.5.0",
-  "description": "fast bufferd line-at-a-time output",
+  "description": "very fast write-combining bufferd output",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -22,10 +22,12 @@
   "keywords": [
     "Andras",
     "fputs",
-    "quick",
+    "very fast",
     "fast",
     "buffered",
     "line",
+    "binary",
+    "Buffer",
     "output",
     "text",
     "newline",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.2.3",
+  "version": "1.2.4-pre",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.2.4-pre",
+  "version": "1.3.0",
   "description": "fast bufferd line-at-a-time output",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "very fast write-combining bufferd output",
   "license": "Apache-2.0",
   "repository": {
@@ -35,10 +35,10 @@
     "transport"
   ],
   "dependencies": {
-    "aflow": "0.9.3",
-    "fs-ext": "0.3.2"
+    "aflow": "0.10.0",
+    "fs-ext": "0.5.0"
   },
   "devDependencies": {
-    "nodeunit": "0.9.0"
+    "qnit": "0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qfputs",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "very fast write-combining bufferd output",
   "license": "Apache-2.0",
   "repository": {

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -248,6 +248,33 @@ module.exports = {
         });
     },
 
+    'FileWriter.write should write entire string': function(t) {
+        var self = this;
+        this.fileWriter.write("test123", function(err) {
+            t.equal(fs.readFileSync(self.tempfile), "test123");
+            t.done();
+        });
+    },
+
+    'FileWriter.write should limit bytes': function(t) {
+        var self = this;
+        this.fileWriter.write("test123", 5, function(err) {
+            t.equal(fs.readFileSync(self.tempfile), "test1");
+            t.done();
+        });
+    },
+
+    'FileWriter.write should write buffers': function(t) {
+        var self = this;
+        this.fileWriter.write(new Buffer("test123"), function(err) {
+            t.equal(fs.readFileSync(self.tempfile), "test123");
+            self.fileWriter.write(new Buffer("test123"), 5, function(err) {
+                t.equal(fs.readFileSync(self.tempfile), "test123test1");
+                t.done();
+            });
+        });
+    },
+
     'FileWriter.renameFile should rename file': function(t) {
         var self = this;
         fs.writeFileSync(this.tempfile, "test");

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -312,8 +312,9 @@ module.exports = {
         var t1 = Date.now();
         setTimeout(function(){ fse.flockSync(fd, 'un'); fs.closeSync(fd) }, 125);
         var self = this;
-        t.expect(2);
+        t.expect(3);
         Fputs.FileWriter.renameFile(this.tempfile, this.tempfile2, function(err, ret) {
+            t.ifError(err);
             t.ok(Date.now() >= t1 + 125);
             t.equal(fs.readFileSync(self.tempfile2).toString(), "test4");
             t.done();

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -387,11 +387,10 @@ module.exports = {
             setTimeout(function(){ fse.flockSync(fd, 'un'); fs.closeSync(fd) }, 200);
             var self = this;
             t.expect(3);
-            Fputs.FileWriter.mutexTimeout = 125;
-            Fputs.FileWriter.renameFile(this.tempfile, this.tempfile2, function(err, ret) {
+            Fputs.FileWriter.renameFile(this.tempfile, this.tempfile2, {mutexTimeout: 125, waitMs: 10}, function(err, ret) {
                 t.ok(err);
                 t.ok(Date.now() >= t1 + 125);
-                t.ok(Date.now() < t1 + 200);
+                t.ok(Date.now() < t1 + 150);
                 // note: node does not exit while fd is locked
                 fse.flockSync(fd, 'un');
                 t.done();

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -143,6 +143,20 @@ module.exports = {
         });
     },
 
+    'abort should discard unwritten data': function(t) {
+        t.expect(4);
+        this.fp.fputs("test 1\n");
+        t.ok(this.fp._syncing);
+        t.ok(this.fp.datachunks[0]);
+        var self = this;
+        this.fp.abort(function(err) {
+            t.ifError(err);
+            var contents = self.writer.getContents();
+            t.equals(contents, "");
+            t.done();
+        });
+    },
+
     'setOnError handler should report errors before fflush callback runs': function(t) {
         var writer = new Fputs.FileWriter("/nonesuch", "a");
         var fp = new Fputs(writer);

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -170,6 +170,29 @@ module.exports = {
         });
     },
 
+    'getUnwrittenLength': {
+        'should return unwritten chars for strings': function(t) {
+            var self = this;
+            this.fp.write("test\x81\n");
+            t.equal(this.fp.getUnwrittenLength(), 6);
+            this.fp.write("test\x82\n");
+            t.equal(this.fp.getUnwrittenLength(), 12);
+            this.fp.fflush(function(err) {
+                t.equal(self.fp.getUnwrittenLength(), 0);
+                t.done();
+            });
+        },
+
+        'should return unwritten bytes for string followed by buffer': function(t) {
+            var self = this;
+            this.fp.write("test\x81\n");
+            this.fp.write("test\x82\n");
+            this.fp.write(new Buffer("test3\n"));
+            t.equal(this.fp.getUnwrittenLength(), 20);
+            t.done();
+        },
+    },
+
     'drain should write pending data': function(t) {
         this.fp.fputs("test 1\n");
         var self = this;

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -21,7 +21,7 @@ module.exports = {
         this.tempfile2 = tempfile2;
         this.mockWriter = {
             written: [],
-            write: function(str, cb) { this.written.push(str); cb(); },
+            write: function(str, cb) { this.written.push("" + str); cb(); },
             fflush: function(cb) { cb(); },
             sync: function(cb) { cb(); },
             getContents: function() { return this.written.join(''); },
@@ -256,22 +256,11 @@ module.exports = {
         });
     },
 
-    'FileWriter.write should limit bytes': function(t) {
-        var self = this;
-        this.fileWriter.write("test123", 5, function(err) {
-            t.equal(fs.readFileSync(self.tempfile), "test1");
-            t.done();
-        });
-    },
-
     'FileWriter.write should write buffers': function(t) {
         var self = this;
         this.fileWriter.write(new Buffer("test123"), function(err) {
             t.equal(fs.readFileSync(self.tempfile), "test123");
-            self.fileWriter.write(new Buffer("test123"), 5, function(err) {
-                t.equal(fs.readFileSync(self.tempfile), "test123test1");
-                t.done();
-            });
+            t.done();
         });
     },
 

--- a/test/test-qfputs.js
+++ b/test/test-qfputs.js
@@ -143,6 +143,19 @@ module.exports = {
         });
     },
 
+    'setOnError handler should report errors before fflush callback runs': function(t) {
+        var writer = new Fputs.FileWriter("/nonesuch", "a");
+        var fp = new Fputs(writer);
+        var error = null;
+        fp.setOnError(function(err) { error = err });
+        fp.write("data");
+        fp.fflush(function(err) {
+            t.ok(!err, "fflush callback should not return error");
+            t.ok(error instanceof Error, "setOnError should have reported the error");
+            t.done();
+        });
+    },
+
     'drain should write pending data': function(t) {
         this.fp.fputs("test 1\n");
         var self = this;


### PR DESCRIPTION
all changes between 1.2.7 and 1.7.0

The sources forked at 1.3, the 1.3 branch having been extensively refactored
per code review feedback.  The 1.2.x versions include back-ports of bug fixes,
but not the new features.

The changes include a much cleaner implementation of `renameFile`, the
ability to efficiently write an arbitrary mix of both buffers and strings, and calls
to set an error callback and to abort writing and discard any unwritten data.